### PR TITLE
Fix Encode Claim

### DIFF
--- a/src/airdrop/encode.py
+++ b/src/airdrop/encode.py
@@ -56,6 +56,9 @@ class ClaimMethods(Enum):
     REGULAR = "claimVestedTokens"
     MODULE = "claimVestedTokensViaModule"
 
+    def __str__(self) -> str:
+        return str(self.value)
+
 
 def encode_claim(
     allocation: Allocation,
@@ -67,11 +70,10 @@ def encode_claim(
     """
     # Could also use allocation.as_claim_params(beneficiary) - not sure what is better.
     claim_params = [allocation.vestingId, beneficiary, MAX_U128]
-
     return SafeTransaction(
         to=AIRDROP_CONTRACT.address,
         value=0,
-        data=AIRDROP_CONTRACT.encodeABI(method, claim_params),
+        data=AIRDROP_CONTRACT.encodeABI(str(method), claim_params),
         operation=SafeOperation.CALL,
     )
 


### PR DESCRIPTION
We got this error when trying to claim (because we were passing an Enum object into the encodeABI call). This should fix it:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/src/exec.py", line 53, in <module>
    transactions = transactions_for(parent, children, command.as_airdrop_command())
  File "/src/airdrop/tx.py", line 41, in transactions_for
    return [
  File "/src/airdrop/tx.py", line 42, in <listcomp>
    build_and_sign_claim(
  File "/src/airdrop/encode.py", line 94, in build_and_sign_claim
    encode_claim(
  File "/src/airdrop/encode.py", line 74, in encode_claim
    data=AIRDROP_CONTRACT.encodeABI(method, claim_params),
  File "/usr/local/lib/python3.10/site-packages/eth_utils/decorators.py", line 18, in _wrapper
    return self.method(obj, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/web3/contract.py", line 408, in encodeABI
    fn_abi, fn_selector, fn_arguments = get_function_info(
  File "/usr/local/lib/python3.10/site-packages/web3/_utils/contracts.py", line 304, in get_function_info
    fn_abi = find_matching_fn_abi(contract_abi, abi_codec, fn_name, args, kwargs)
  File "/usr/local/lib/python3.10/site-packages/web3/_utils/contracts.py", line 124, in find_matching_fn_abi
    raise TypeError("Unsupported function identifier")
TypeError: Unsupported function identifier
```