### PR TITLE
[$SAFE Airdrop] Full Multi Claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Requires additional arguments `--new-owner NEW_OWNER`
 
 ### Airdrop
 
+Individual commands are supported as well as "Full Claim" (--command FullClaim)
+which combines delegate, redeem and claim into a single transaction. 
+Note: that this is **not** recommended for more than 26 SubSafes at a time
+
 #### Redeem
 
 Requires no additional arguments

--- a/src/exec.py
+++ b/src/exec.py
@@ -25,6 +25,7 @@ class ExecCommand(Enum):
     ADD_OWNER = "ADD_OWNER"
     SET_DELEGATE = "setDelegate"
     CLEAR_DELEGATE = "clearDelegate"
+    DELEGATE_REDEEM_CLAIM = "FullClaim"
 
     def __str__(self) -> str:
         return str(self.value)
@@ -60,7 +61,18 @@ if __name__ == "__main__":
     args, _ = parser.parse_known_args()
     command: ExecCommand = args.command
 
-    if command.is_airdrop_function():
+    if command == ExecCommand.DELEGATE_REDEEM_CLAIM:
+        delegates = snapshot_tx_for(
+            parent, children, ExecCommand.SET_DELEGATE.as_snapshot_command()
+        )
+        redeems = airdrop_tx_for(
+            parent, children, ExecCommand.REDEEM.as_airdrop_command()
+        )
+        claims = airdrop_tx_for(
+            parent, children, ExecCommand.CLAIM.as_airdrop_command()
+        )
+        transactions = delegates + redeems + claims
+    elif command.is_airdrop_function():
         transactions = airdrop_tx_for(parent, children, command.as_airdrop_command())
     elif command.is_snapshot_function():
         transactions = snapshot_tx_for(parent, children, command.as_snapshot_command())


### PR DESCRIPTION
Add Full Claim feature to [Delegate, Redeem and Claim SAFE Airdrop] (limited to <=26 safes) because of the capped limit of 80 transactions and (80 / 3 ~ 26).

## Test Plan
Create `.env` file as 
```shell
# General defaults
NETWORK=mainnet
INDEX_FROM=0
NUM_SAFES=80 <-- This is the CAP.
# Must be provided
INFURA_KEY=
PARENT_SAFE=
# Private key of Parent Owner
PROPOSER_PK=
DUNE_API_KEY=
```

```
docker run --pull=always -it --rm \
  --env-file .env \
  ghcr.io/bh2smith/subsafe-commander:main \
  --command FullClaim \
  --parent $PARENT_SAFE \
  --index-from $INDEX_FROM \
  --num-safes $NUM_SAFES