### PR TITLE
Partition Large Batches

### DIFF
--- a/src/multisend.py
+++ b/src/multisend.py
@@ -4,6 +4,7 @@ Safe Multisend transaction consisting of Transfers
 """
 import logging.config
 import sys
+from typing import Optional
 
 from eth_typing.encoding import HexStr
 from gnosis.eth.ethereum_client import EthereumClient
@@ -12,9 +13,14 @@ from gnosis.safe.api import TransactionServiceApi
 from gnosis.safe.api.base_api import SafeAPIException
 from gnosis.safe.multi_send import MultiSend, MultiSendTx, MultiSendOperation
 
+from src.util import partition_array
+
 log = logging.getLogger(__name__)
 
 MULTISEND_CONTRACT = "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D"
+# See benchmarks:
+# https://github.com/bh2smith/subsafe-commander/issues/4#issuecomment-1297738947
+BATCH_SIZE_LIMIT = 80
 
 
 def build_encoded_multisend(
@@ -34,7 +40,7 @@ def post_safe_tx(safe_tx: SafeTx, tx_service: TransactionServiceApi) -> int:
     assert safe_tx.signatures != b"", "Attempt to post unsigned transaction!"
     address, tx_hash = safe_tx.safe_address, safe_tx.safe_tx_hash.hex()
     print(f"posting transaction with hash {tx_hash} to {address}")
-    if input("are you sure? (y/n)") != "y":
+    if input("are you sure? (y/n) ") != "y":
         sys.exit()
     try:
         tx_service.post_transaction(safe_tx)
@@ -53,10 +59,16 @@ def build_and_sign_multisend(
     transactions: list[MultiSendTx],
     client: EthereumClient,
     signing_key: str,
+    nonce: Optional[int] = None,
 ) -> SafeTx:
     """
     Constructs and Signs a MultiSend Transaction from a list of Transfers.
     """
+    if len(transactions) <= BATCH_SIZE_LIMIT:
+        raise RuntimeError(
+            "too many transactions for single batch ({len(transactions)}), "
+            "use partitioned_build_multisend!"
+        )
     encoded_multisend = build_encoded_multisend(
         transactions=transactions, client=client
     )
@@ -67,11 +79,35 @@ def build_and_sign_multisend(
         value=0,
         data=encoded_multisend,
         operation=SafeOperation.DELEGATE_CALL.value,
+        safe_nonce=nonce,
     )
     # There is a deep warning being raised here:
     # Details in issue: https://github.com/safe-global/safe-eth-py/issues/294
     safe_tx.sign(signing_key)
     return safe_tx
+
+
+def partitioned_build_multisend(
+    safe: Safe,
+    transactions: list[MultiSendTx],
+    client: EthereumClient,
+    signing_key: str,
+) -> list[SafeTx]:
+    """
+    Partitions transactions according to what will fit in BATCH_SIZE_LIMIT
+    and builds as many transactions as necessary with appropriate nonce
+    beginning from the current nonce of `safe`.
+    """
+    partition = partition_array(transactions, BATCH_SIZE_LIMIT)
+    if len(partition) == 1:
+        log.info("building an executing a single multi-exec transaction")
+    else:
+        log.info(f"partitioned {len(transactions)} into {len(partition)} batches")
+    nonce = safe.retrieve_nonce()
+    return [
+        build_and_sign_multisend(safe, part, client, signing_key, nonce + i)
+        for i, part in enumerate(partition)
+    ]
 
 
 def build_multisend_from_data(safe: Safe, data: HexStr, value: int = 0) -> MultiSendTx:

--- a/src/multisend.py
+++ b/src/multisend.py
@@ -64,9 +64,9 @@ def build_and_sign_multisend(
     """
     Constructs and Signs a MultiSend Transaction from a list of Transfers.
     """
-    if len(transactions) <= BATCH_SIZE_LIMIT:
+    if len(transactions) > BATCH_SIZE_LIMIT:
         raise RuntimeError(
-            "too many transactions for single batch ({len(transactions)}), "
+            f"too many transactions for single batch ({len(transactions)}), "
             "use partitioned_build_multisend!"
         )
     encoded_multisend = build_encoded_multisend(

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,9 @@
+"""Some reusable generic helper functions"""
+from typing import Any
+
+
+def partition_array(arr: list[Any], part_size: int) -> list[list[Any]]:
+    """Partitions array into parts of size `part_size`"""
+    if part_size <= 0:
+        raise ValueError(f"Can't partition array into parts of size {part_size}")
+    return [arr[i : i + part_size] for i in range(0, len(arr), part_size)]

--- a/tests/unit/test_add_owners.py
+++ b/tests/unit/test_add_owners.py
@@ -97,7 +97,7 @@ class TestMultiAddOwner(unittest.TestCase):
                 for child in self.sub_safes
             ],
             client=self.client,
-            signing_key=os.environ["PROPOSER_PK"],
+            signing_key="0" * 64,
         )
         expected = (
             "0x8d80ff0a"

--- a/tests/unit/test_multisend.py
+++ b/tests/unit/test_multisend.py
@@ -118,16 +118,14 @@ class TestMultiSend(unittest.TestCase):
             str(err.exception),
         )
 
-        with self.assertLogs("src.multisend", level="INFO") as log:
-            partitioned_build_multisend(
+        with self.assertLogs("src.multisend", level="INFO"):
+            txs = partitioned_build_multisend(
                 safe,
                 transactions=too_many_transactions,
                 client=self.client,
                 signing_key="0" * 64,
             )
-            self.assertEqual(
-                f"partitioned {BATCH_SIZE_LIMIT + 1} into 2 batches", log.output
-            )
+        self.assertEqual(len(txs), 2)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,18 @@
+import unittest
+
+from src.util import partition_array
+
+
+class MyTestCase(unittest.TestCase):
+    def test_something(self):
+        arr = [1, 2, 3]
+        self.assertEqual(partition_array(arr, 3), [arr])
+        self.assertEqual(partition_array(arr, 4), [arr])
+        self.assertEqual(partition_array(arr, 2), [[1, 2], [3]])
+        self.assertEqual(partition_array(arr, 1), [[1], [2], [3]])
+        with self.assertRaises(ValueError):
+            partition_array(arr, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We instead of rejecting runs that have too many batches, we partition and post multiple transactions with incremental nonce. 

closes #34 